### PR TITLE
download-attachment-fileボタンにaria-label,tooltipを追加等

### DIFF
--- a/src/assets/custom.scss
+++ b/src/assets/custom.scss
@@ -12,7 +12,7 @@ $htmlTags: div, span, h1, h2, h3, h4, h5, h6, p, pre, a, abbr, address, code, sm
   center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead,
   tr, th, td, article;
 
-#app {
+#app, .v-overlay {
   font-family: $body-font-family;
 
   // Vuetifyのtypography option使用箇所にすべて指定のfont-familyを上書きする

--- a/src/components/Viewer.vue
+++ b/src/components/Viewer.vue
@@ -141,13 +141,23 @@ const onFileUpload = async () => {
         <v-row align="center">            
             <template v-for="attachment in emlData?.attachments">
                 <v-col cols="auto">
-                    <v-btn
-                    :color="attachmentColor(attachment.name)"
-                    prepend-icon="mdi-file"                    
-                    :text="attachment.name"
-                    variant="outlined"
-                    @click="downloadAttachmentFile(attachment)"
-                    ></v-btn>                    
+                    <v-tooltip
+                    text="添付ファイルをダウンロード"       
+                    location="bottom"   
+                    open-delay="300"          
+                    >
+                    <template v-slot:activator="{ props }">
+                        <v-btn
+                        v-bind="props"
+                        aria-label="添付ファイルをダウンロード"
+                        :color="attachmentColor(attachment.name)"
+                        prepend-icon="mdi-file"                    
+                        :text="attachment.name"
+                        variant="outlined"
+                        @click="downloadAttachmentFile(attachment)"
+                        ></v-btn>
+                    </template>
+                    </v-tooltip>                                        
                 </v-col>
             </template>
         </v-row>


### PR DESCRIPTION
viewer.vue: download-attachment-fileボタンにaria-label,tooltipを追加
custom.scss: v-overlay内の要素にもnoto-sansが適用されるよう修正